### PR TITLE
Bug fix #3

### DIFF
--- a/RAG/RAG.go
+++ b/RAG/RAG.go
@@ -157,6 +157,8 @@ func (r *RAGPineconeGemini) Embed(text string) ([]float32, error) {
 }
 
 func (r *RAGPineconeGemini) Match(namespace string, query string, topK int) ([]*pinecone.ScoredVector, error) {
+	// switch the namespace to the correct namespace
+	conn := r.IndexConn.WithNamespace(namespace)
 	topK += 5 // add 5 to the topK to get more results to replace the missing ones
 	// get the embedding of the query
 	queryEmbedding, err := r.Embed(query)
@@ -168,7 +170,7 @@ func (r *RAGPineconeGemini) Match(namespace string, query string, topK int) ([]*
 	// start a timer
 	startTime := time.Now()
 	// query the vector store
-	results, err := r.IndexConn.QueryByVectorValues(context.Background(), &pinecone.QueryByVectorValuesRequest{
+	results, err := conn.QueryByVectorValues(context.Background(), &pinecone.QueryByVectorValuesRequest{
 		Vector:          queryEmbedding,
 		TopK:            uint32(topK),
 		IncludeMetadata: true,

--- a/RAG/chatbot_conversation_test.go
+++ b/RAG/chatbot_conversation_test.go
@@ -58,7 +58,7 @@ func TestChatbotConversation(t *testing.T) {
 		start := time.Now()
 
 		// Query the chatbot
-		response, err := chatbot.QueryChat("database-docs", query, 3)
+		response, err := chatbot.QueryChat("database-articles", query, 3)
 		if err != nil {
 			t.Fatalf("Failed to query chatbot for query %d: %v", i+1, err)
 		}


### PR DESCRIPTION
Fixes #3 
The `*RAGPineconeGemini.Match()` method was missing a line that uses the same gRPC client but with a different namespace